### PR TITLE
カレンダー画面が重なって描画されるバグの修正

### DIFF
--- a/Release/TIMELAB/TIMELAB.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Release/TIMELAB/TIMELAB.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
         "branch" : "master",
-        "revision" : "5a4702f7a6d14b27f6cf7c60c3c86a3116421bec"
+        "revision" : "3b8e5553b52eaff141ba67bd7c34f05b40a0c933"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "71eb6700dd53a851473c48d392f00a3ab26699a6",
-        "version" : "10.1.0"
+        "revision" : "04351180d4c757c6c16127cb57b685fff9ef260b",
+        "version" : "10.6.0"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "6db6edb48bdd9943426562c7f042a5492de5ba3d",
-        "version" : "7.10.0"
+        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
+        "version" : "7.11.0"
       }
     },
     {

--- a/Release/TIMELAB/TIMELAB/View/CalendarView/CalendarViewController.swift
+++ b/Release/TIMELAB/TIMELAB/View/CalendarView/CalendarViewController.swift
@@ -61,6 +61,7 @@ class CalendarViewController: UIViewController {
         
         navigationItem.title = "カレンダー"
         view.backgroundColor = .white
+        self.calendarView = CalendarView(dateAndStayingTimeDic: self.enterScheduleAndStayingTimeDic)
         HUD.show(.progress)
         setupMonthCalendarTime()
 //        setupLayout()   // setupMonthCalendarTime() 内で呼ばれる
@@ -129,7 +130,7 @@ class CalendarViewController: UIViewController {
                     }
                 }
                 self.times = newMonthCalndarTimes   // 日毎の詳細画面に使用
-                
+                self.calendarView.enterScheduleAndStayingTimeDic = self.enterScheduleAndStayingTimeDic
                 self.setupLayout()
                 self.setupBinding()
                 self.setupFloatingPanel()
@@ -202,8 +203,6 @@ class CalendarViewController: UIViewController {
         
         view.backgroundColor = .white
         
-        // カレンダー の描画
-        calendarView = CalendarView(dateAndStayingTimeDic: enterScheduleAndStayingTimeDic)
         calendarView.calendarViewDelegate = self   // 画面遷移のために指定
         
         // カレンダーセルの説明


### PR DESCRIPTION
close #39 
入退室時刻をDIすることで、画面が重なって描画されるバグを解消