### PR TITLE
fix: QR読み取り画面を閉じた時、カメラのタスクを切る

### DIFF
--- a/Release/TIMELAB/TIMELAB/View/QrCodeScannerView/QrCodeScannerViewController.swift
+++ b/Release/TIMELAB/TIMELAB/View/QrCodeScannerView/QrCodeScannerViewController.swift
@@ -50,6 +50,8 @@ class QrCodeScannerViewController: UIViewController {
     }
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+
+        qrCodeScannerView.stopRunning()
         if #available(iOS 13.0, *) {
             presentingViewController?.beginAppearanceTransition(true, animated: animated)
             presentingViewController?.endAppearanceTransition()


### PR DESCRIPTION
## 何をしたか (一言で)

QR読み取り画面を閉じた時カメラのタスクを切る

## 詳細

- QR読み取りに使用している[メルカリのOSS](https://engineering.mercari.com/blog/entry/2019-12-12-094129/#%E3%82%BD%E3%83%BC%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%89%E3%81%A7%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%9E%E3%82%A4%E3%82%BA)の実装を確認
- QR読み取り画面を閉じたタイミング(viewWillDisappear) で `.stopRunnning()`メソッドを呼び出す

## 変更 (UI)
**GIFなし**

QR読み取り画面を閉じると、iPhone画面右上の緑色マークが消える